### PR TITLE
Updating README.md w/ valid install command

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,10 +10,8 @@ Official mysql plugin for dokku. Currently defaults to installing [mysql 5.6.26]
 ## installation
 
 ```
-cd /var/lib/dokku/plugins
-git clone https://github.com/dokku/dokku-mysql.git mysql
-dokku plugins-install-dependencies
-dokku plugins-install
+dokku plugin:install-dependencies
+dokku plugin:install https://github.com/dokku/dokku-mysql.git
 ```
 
 ## commands


### PR DESCRIPTION
The readme appears to contain commands to install this plugin for an older version of dokku. Since the readme mentions requiring 0.4.0, I've updated it to show the commands which work for installing this plugin. Someone more familiar with dokku should review how plugin:install-dependencies is handled here, as it could be incorrect.