### PR TITLE
Read MYSQL_DATABASE_SCHEME variable from app when setting DATABASE_URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,3 +129,30 @@ dokku mysql:clone lolipop new_database
 # finally, you can destroy the container
 dokku mysql:destroy lolipop
 ```
+
+## Changing database adapter
+
+It's possible to change the protocol for DATABASE_URL by setting
+the environment variable DATABASE_ADAPTER on the app:
+
+```
+dokku config:set lolipop DATABASE_ADAPTER=mysql2
+dokku mysql:link lolipop playground
+```
+
+Will cause DATABASE_URL to be set as
+mysql2://mysql:SOME_PASSWORD@dokku-mysql-lolipop:3306/lolipop
+
+CAUTION: Changing DATABASE_ADAPTER after linking will cause dokku to believe
+the service is not linked when attempting to use `dokku mysql:unlink` or
+`dokku mysql:promote`.
+You should be able to fix this by
+
+- Changing DATABASE_URL manually to the new value.
+
+OR
+
+- Set DATABASE_ADAPTER back to its original setting
+- Unlink the service
+- Change DATABASE_ADAPTER to the desired setting
+- Relink the service

--- a/README.md
+++ b/README.md
@@ -133,17 +133,17 @@ dokku mysql:destroy lolipop
 ## Changing database adapter
 
 It's possible to change the protocol for DATABASE_URL by setting
-the environment variable DATABASE_ADAPTER on the app:
+the environment variable DATABASE_SCHEME on the app:
 
 ```
-dokku config:set playground DATABASE_ADAPTER=mysql2
+dokku config:set playground DATABASE_SCHEME=mysql2
 dokku mysql:link lolipop playground
 ```
 
 Will cause DATABASE_URL to be set as
 mysql2://mysql:SOME_PASSWORD@dokku-mysql-lolipop:3306/lolipop
 
-CAUTION: Changing DATABASE_ADAPTER after linking will cause dokku to believe
+CAUTION: Changing DATABASE_SCHEME after linking will cause dokku to believe
 the service is not linked when attempting to use `dokku mysql:unlink` or
 `dokku mysql:promote`.
 You should be able to fix this by
@@ -152,7 +152,7 @@ You should be able to fix this by
 
 OR
 
-- Set DATABASE_ADAPTER back to its original setting
+- Set DATABASE_SCHEME back to its original setting
 - Unlink the service
-- Change DATABASE_ADAPTER to the desired setting
+- Change DATABASE_SCHEME to the desired setting
 - Relink the service

--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ It's possible to change the protocol for DATABASE_URL by setting
 the environment variable DATABASE_ADAPTER on the app:
 
 ```
-dokku config:set lolipop DATABASE_ADAPTER=mysql2
+dokku config:set playground DATABASE_ADAPTER=mysql2
 dokku mysql:link lolipop playground
 ```
 

--- a/README.md
+++ b/README.md
@@ -133,26 +133,26 @@ dokku mysql:destroy lolipop
 ## Changing database adapter
 
 It's possible to change the protocol for DATABASE_URL by setting
-the environment variable DATABASE_SCHEME on the app:
+the environment variable MYSQL_DATABASE_SCHEME on the app:
 
 ```
-dokku config:set playground DATABASE_SCHEME=mysql2
+dokku config:set playground MYSQL_DATABASE_SCHEME=mysql2
 dokku mysql:link lolipop playground
 ```
 
 Will cause DATABASE_URL to be set as
 mysql2://mysql:SOME_PASSWORD@dokku-mysql-lolipop:3306/lolipop
 
-CAUTION: Changing DATABASE_SCHEME after linking will cause dokku to believe
-the service is not linked when attempting to use `dokku mysql:unlink` or
-`dokku mysql:promote`.
+CAUTION: Changing MYSQL_DATABASE_SCHEME after linking will cause dokku to
+believe the service is not linked when attempting to use `dokku mysql:unlink`
+or `dokku mysql:promote`.
 You should be able to fix this by
 
 - Changing DATABASE_URL manually to the new value.
 
 OR
 
-- Set DATABASE_SCHEME back to its original setting
+- Set MYSQL_DATABASE_SCHEME back to its original setting
 - Unlink the service
-- Change DATABASE_SCHEME to the desired setting
+- Change MYSQL_DATABASE_SCHEME to the desired setting
 - Relink the service

--- a/functions
+++ b/functions
@@ -357,6 +357,6 @@ service_linked_apps() {
 
 update_plugin_scheme_for_app() {
   local APP=$1
-  local DATABASE_ADAPTER=$(config_get $APP DATABASE_ADAPTER)
-  PLUGIN_SCHEME=${DATABASE_ADAPTER:-$PLUGIN_SCHEME}
+  local DATABASE_SCHEME=$(config_get $APP DATABASE_SCHEME)
+  PLUGIN_SCHEME=${DATABASE_SCHEME:-$PLUGIN_SCHEME}
 }

--- a/functions
+++ b/functions
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 set -eo pipefail; [[ $DOKKU_TRACE ]] && set -x
 source "$(dirname "$0")/config"
+source "$PLUGIN_AVAILABLE_PATH/config/functions"
 
 get_random_ports() {
   local iterations="${1:-1}"
@@ -356,6 +357,6 @@ service_linked_apps() {
 
 update_plugin_scheme_for_app() {
   local APP=$1
-  local DATABASE_ADAPTER=$(dokku config:get $APP DATABASE_ADAPTER)
+  local DATABASE_ADAPTER=$(config_get $APP DATABASE_ADAPTER)
   PLUGIN_SCHEME=${DATABASE_ADAPTER:-$PLUGIN_SCHEME}
 }

--- a/functions
+++ b/functions
@@ -357,6 +357,6 @@ service_linked_apps() {
 
 update_plugin_scheme_for_app() {
   local APP=$1
-  local DATABASE_SCHEME=$(config_get $APP DATABASE_SCHEME)
-  PLUGIN_SCHEME=${DATABASE_SCHEME:-$PLUGIN_SCHEME}
+  local MYSQL_DATABASE_SCHEME=$(config_get $APP MYSQL_DATABASE_SCHEME)
+  PLUGIN_SCHEME=${MYSQL_DATABASE_SCHEME:-$PLUGIN_SCHEME}
 }

--- a/functions
+++ b/functions
@@ -70,6 +70,7 @@ service_exposed_ports() {
 service_link() {
   local APP="$2"
   local SERVICE="$1"
+  update_plugin_scheme_for_app "$APP"
   local SERVICE_URL=$(service_url "$SERVICE")
   local SERVICE_NAME=$(get_service_name "$SERVICE")
   local SERVICE_ROOT="$PLUGIN_DATA_ROOT/$SERVICE"
@@ -253,6 +254,7 @@ service_stop() {
 service_unlink() {
   local APP="$2"
   local SERVICE="$1"
+  update_plugin_scheme_for_app "$APP"
   local SERVICE_URL=$(service_url "$SERVICE")
   local SERVICE_NAME=$(get_service_name "$SERVICE")
   local EXISTING_CONFIG=$(dokku config "$APP")
@@ -309,6 +311,7 @@ promote() {
   local APP="$2"
   local PLUGIN_DEFAULT_CONFIG_VAR="${PLUGIN_DEFAULT_ALIAS}_URL"
   local EXISTING_CONFIG=$(dokku config "$APP")
+  update_plugin_scheme_for_app "$APP"
   local SERVICE_URL=$(service_url "$SERVICE")
   local CONFIG_VARS=($(echo "$EXISTING_CONFIG" | grep "$SERVICE_URL" | cut -d: -f1)) || true
   local PREVIOUS_DEFAULT_URL=$(get_url_from_config "$EXISTING_CONFIG" "$PLUGIN_DEFAULT_CONFIG_VAR")
@@ -349,4 +352,10 @@ service_linked_apps() {
   [[ -z $(< "$LINKS_FILE") ]] && echo '-' && return 0
 
   tr '\n' ' ' < "$LINKS_FILE"
+}
+
+update_plugin_scheme_for_app() {
+  local APP=$1
+  local DATABASE_ADAPTER=$(dokku config:get $APP DATABASE_ADAPTER)
+  PLUGIN_SCHEME=${DATABASE_ADAPTER:-$PLUGIN_SCHEME}
 }

--- a/tests/service_link.bats
+++ b/tests/service_link.bats
@@ -60,8 +60,8 @@ teardown() {
   dokku "$PLUGIN_COMMAND_PREFIX:unlink" l my_app
 }
 
-@test "($PLUGIN_COMMAND_PREFIX:link) uses apps DATABASE_SCHEME variable" {
-  dokku config:set my_app DATABASE_SCHEME=mysql2
+@test "($PLUGIN_COMMAND_PREFIX:link) uses apps MYSQL_DATABASE_SCHEME variable" {
+  dokku config:set my_app MYSQL_DATABASE_SCHEME=mysql2
   dokku "$PLUGIN_COMMAND_PREFIX:link" l my_app
   url=$(dokku config:get my_app DATABASE_URL)
   password="$(cat "$PLUGIN_DATA_ROOT/l/PASSWORD")"

--- a/tests/service_link.bats
+++ b/tests/service_link.bats
@@ -60,8 +60,8 @@ teardown() {
   dokku "$PLUGIN_COMMAND_PREFIX:unlink" l my_app
 }
 
-@test "($PLUGIN_COMMAND_PREFIX:link) uses apps DATABASE_ADAPTER variable" {
-  dokku config:set my_app DATABASE_ADAPTER=mysql2
+@test "($PLUGIN_COMMAND_PREFIX:link) uses apps DATABASE_SCHEME variable" {
+  dokku config:set my_app DATABASE_SCHEME=mysql2
   dokku "$PLUGIN_COMMAND_PREFIX:link" l my_app
   url=$(dokku config:get my_app DATABASE_URL)
   password="$(cat "$PLUGIN_DATA_ROOT/l/PASSWORD")"

--- a/tests/service_link.bats
+++ b/tests/service_link.bats
@@ -59,3 +59,12 @@ teardown() {
   assert_contains "${lines[*]}" "--link dokku.mysql.l:dokku-mysql-l"
   dokku "$PLUGIN_COMMAND_PREFIX:unlink" l my_app
 }
+
+@test "($PLUGIN_COMMAND_PREFIX:link) uses apps DATABASE_ADAPTER variable" {
+  dokku config:set my_app DATABASE_ADAPTER=mysql2
+  dokku "$PLUGIN_COMMAND_PREFIX:link" l my_app
+  url=$(dokku config:get my_app DATABASE_URL)
+  password="$(cat "$PLUGIN_DATA_ROOT/l/PASSWORD")"
+  assert_contains "$url" "mysql2://mysql:$password@dokku-mysql-l:3306/l"
+  dokku "$PLUGIN_COMMAND_PREFIX:unlink" l my_app
+}

--- a/tests/service_promote.bats
+++ b/tests/service_promote.bats
@@ -54,9 +54,9 @@ teardown() {
   assert_contains "${lines[*]}" "DOKKU_MYSQL_"
 }
 
-@test "($PLUGIN_COMMAND_PREFIX:promote) uses DATABASE_ADAPTER variable" {
+@test "($PLUGIN_COMMAND_PREFIX:promote) uses DATABASE_SCHEME variable" {
   password="$(cat "$PLUGIN_DATA_ROOT/l/PASSWORD")"
-  dokku config:set my_app "DATABASE_ADAPTER=mysql2" "DATABASE_URL=mysql://u:p@host:3306/db" "DOKKU_MYSQL_BLUE_URL=mysql2://mysql:$password@dokku-mysql-l:3306/l"
+  dokku config:set my_app "DATABASE_SCHEME=mysql2" "DATABASE_URL=mysql://u:p@host:3306/db" "DOKKU_MYSQL_BLUE_URL=mysql2://mysql:$password@dokku-mysql-l:3306/l"
   dokku "$PLUGIN_COMMAND_PREFIX:promote" l my_app
   url=$(dokku config:get my_app DATABASE_URL)
   assert_contains "$url" "mysql2://mysql:$password@dokku-mysql-l:3306/l"

--- a/tests/service_promote.bats
+++ b/tests/service_promote.bats
@@ -54,9 +54,9 @@ teardown() {
   assert_contains "${lines[*]}" "DOKKU_MYSQL_"
 }
 
-@test "($PLUGIN_COMMAND_PREFIX:promote) uses DATABASE_SCHEME variable" {
+@test "($PLUGIN_COMMAND_PREFIX:promote) uses MYSQL_DATABASE_SCHEME variable" {
   password="$(cat "$PLUGIN_DATA_ROOT/l/PASSWORD")"
-  dokku config:set my_app "DATABASE_SCHEME=mysql2" "DATABASE_URL=mysql://u:p@host:3306/db" "DOKKU_MYSQL_BLUE_URL=mysql2://mysql:$password@dokku-mysql-l:3306/l"
+  dokku config:set my_app "MYSQL_DATABASE_SCHEME=mysql2" "DATABASE_URL=mysql://u:p@host:3306/db" "DOKKU_MYSQL_BLUE_URL=mysql2://mysql:$password@dokku-mysql-l:3306/l"
   dokku "$PLUGIN_COMMAND_PREFIX:promote" l my_app
   url=$(dokku config:get my_app DATABASE_URL)
   assert_contains "$url" "mysql2://mysql:$password@dokku-mysql-l:3306/l"

--- a/tests/service_promote.bats
+++ b/tests/service_promote.bats
@@ -53,3 +53,11 @@ teardown() {
   run dokku config my_app
   assert_contains "${lines[*]}" "DOKKU_MYSQL_"
 }
+
+@test "($PLUGIN_COMMAND_PREFIX:promote) uses DATABASE_ADAPTER variable" {
+  password="$(cat "$PLUGIN_DATA_ROOT/l/PASSWORD")"
+  dokku config:set my_app "DATABASE_ADAPTER=mysql2" "DATABASE_URL=mysql://u:p@host:3306/db" "DOKKU_MYSQL_BLUE_URL=mysql2://mysql:$password@dokku-mysql-l:3306/l"
+  dokku "$PLUGIN_COMMAND_PREFIX:promote" l my_app
+  url=$(dokku config:get my_app DATABASE_URL)
+  assert_contains "$url" "mysql2://mysql:$password@dokku-mysql-l:3306/l"
+}


### PR DESCRIPTION
If MYSQL_DATABASE_SCHEME environment variable is set on the app when `dokku mysql:link` or `dokku mysql:promote` are run this will cause DATABASE_URL to use the specified MYSQL_DATABASE_SCHEME as the protocol part of the URL.

e.g.:

    dokku config:set my_app MYSQL_DATABASE_SCHEME=mysql2
    dokku mysql:link db my_app

So that Active Record tries to use the 'mysql2' gem instead of 'mysql'. Defaults to PLUGIN_SCHEME set in config if no MYSQL_DATABASE_SCHEME is set (or value is null).

README.md includes note about changing MYSQL_DATABASE_SCHEME with services already linked but some kind of cleverer automated resolution would probably be better.

Proposed solution for #33.  What do you think @josegonzalez ? Bash scripting is not my forte so feel free to rip this apart if there's a better solution.