### PR TITLE
Use utf8 character set as default

### DIFF
--- a/functions
+++ b/functions
@@ -24,6 +24,7 @@ service_create() {
   mkdir -p "$SERVICE_ROOT/config" || dokku_log_fail "Unable to create service config directory"
   touch "$LINKS_FILE"
   echo -e "[mysqld]\nperformance_schema = 0" > "$SERVICE_ROOT/config/disable_performance_schema.cnf"
+  echo -e "[mysqld]\ncharacter-set-server = utf8\ncollation-server = utf8_general_ci" > "$SERVICE_ROOT/config/charset_utf8.cnf"
   rootpassword=$(openssl rand -hex 8)
   password=$(openssl rand -hex 8)
   echo "$rootpassword" > "$SERVICE_ROOT/ROOTPASSWORD"


### PR DESCRIPTION
I believe it is reasonable to use utf8 as the default charset in MySQL databases. This PR makes the dokku plugin use this charset as default.