### PR TITLE
Fix error in backup scheduling

### DIFF
--- a/install
+++ b/install
@@ -26,6 +26,7 @@ plugin-install() {
   cat > "$_SUDOERS_FILE" <<EOL
 %dokku ALL=(ALL) NOPASSWD:/bin/rm -f /etc/cron.d/dokku-${PLUGIN_COMMAND_PREFIX}-*
 %dokku ALL=(ALL) NOPASSWD:/bin/chown root\:root /etc/cron.d/dokku-${PLUGIN_COMMAND_PREFIX}-*
+%dokku ALL=(ALL) NOPASSWD:/bin/chmod 644 /etc/cron.d/dokku-${PLUGIN_COMMAND_PREFIX}-*
 %dokku ALL=(ALL) NOPASSWD:/bin/mv ${PLUGIN_DATA_ROOT}/.TMP_CRON_FILE /etc/cron.d/dokku-${PLUGIN_COMMAND_PREFIX}-*
 %dokku ALL=(ALL) NOPASSWD:/bin/chown 8983 $PLUGIN_DATA_ROOT/*
 %dokku ALL=(ALL) NOPASSWD:/bin/chgrp 8983 $PLUGIN_DATA_ROOT/*


### PR DESCRIPTION
When trying to schedule a backup, the command fails with the error:
```
Sorry, user dokku is not allowed to execute '/bin/chmod 644 /etc/cron.d/dokku-mysql-database-name' as root on dokku-host-name
```
This commit takes care of it.