### PR TITLE
Suppress mysqldump password error.

### DIFF
--- a/functions
+++ b/functions
@@ -63,7 +63,9 @@ service_export() {
   local PASSWORD="$(cat "$SERVICE_ROOT/PASSWORD")"
 
   [[ -n $SSH_TTY ]] && stty -opost
-  docker exec "$SERVICE_NAME" mysqldump --user=mysql --password="$PASSWORD" "$SERVICE"
+  docker exec "$SERVICE_NAME" bash -c "printf '[client]\npassword=$PASSWORD\n' > /root/credentials.cnf"
+  docker exec "$SERVICE_NAME" mysqldump --defaults-extra-file=/root/credentials.cnf --user=mysql "$SERVICE"
+  docker exec "$SERVICE_NAME" rm /root/credentials.cnf
   status=$?
   [[ -n $SSH_TTY ]] && stty opost
   exit $status

--- a/tests/service_export.bats
+++ b/tests/service_export.bats
@@ -24,17 +24,21 @@ teardown() {
 @test "($PLUGIN_COMMAND_PREFIX:export) success with SSH_TTY" {
   export ECHO_DOCKER_COMMAND="true"
   export SSH_TTY=`tty`
-  run dokku "$PLUGIN_COMMAND_PREFIX:export" l
   password="$(cat "$PLUGIN_DATA_ROOT/l/PASSWORD")"
+  run dokku "$PLUGIN_COMMAND_PREFIX:export" l
   assert_exit_status 0
-  assert_output "docker exec dokku.mysql.l mysqldump --user=mysql --password=$password l"
+  assert_output "docker exec dokku.mysql.l bash -c printf '[client]\npassword=$password\n' > /root/credentials.cnf
+docker exec dokku.mysql.l mysqldump --defaults-extra-file=/root/credentials.cnf --user=mysql l
+docker exec dokku.mysql.l rm /root/credentials.cnf"
 }
 
 @test "($PLUGIN_COMMAND_PREFIX:export) success without SSH_TTY" {
   export ECHO_DOCKER_COMMAND="true"
   unset SSH_TTY
-  run dokku "$PLUGIN_COMMAND_PREFIX:export" l
   password="$(cat "$PLUGIN_DATA_ROOT/l/PASSWORD")"
+  run dokku "$PLUGIN_COMMAND_PREFIX:export" l
   assert_exit_status 0
-  assert_output "docker exec dokku.mysql.l mysqldump --user=mysql --password=$password l"
+  assert_output "docker exec dokku.mysql.l bash -c printf '[client]\npassword=$password\n' > /root/credentials.cnf
+docker exec dokku.mysql.l mysqldump --defaults-extra-file=/root/credentials.cnf --user=mysql l
+docker exec dokku.mysql.l rm /root/credentials.cnf"
 }


### PR DESCRIPTION
This PR suppresses the warning `mysqldump: [Warning] Using a password on the command line interface can be insecure.` by temporarily creating a credentials file which is then used by mysqldump.

I wanted to run the `dokku mysql:export` command from a cron but because of this warning it would always return a faulty exit code. Evidently receiving an email from cron with the warning each time a backup would be made.

Let me know if you'd like me to make changes to the PR :)