### PR TITLE
Faster exporting for innodb tables

### DIFF
--- a/functions
+++ b/functions
@@ -101,7 +101,7 @@ service_export() {
 
   [[ -n $SSH_TTY ]] && stty -opost
   docker exec "$SERVICE_NAME" bash -c "printf '[client]\npassword=$PASSWORD\n' > /root/credentials.cnf"
-  docker exec "$SERVICE_NAME" mysqldump --defaults-extra-file=/root/credentials.cnf --user=mysql "$DATABASE_NAME"
+  docker exec "$SERVICE_NAME" mysqldump --defaults-extra-file=/root/credentials.cnf --user=mysql --single-transaction --quick  "$DATABASE_NAME"
   docker exec "$SERVICE_NAME" rm /root/credentials.cnf
   status=$?
   [[ -n $SSH_TTY ]] && stty opost


### PR DESCRIPTION
Since InnoDB is the standard, i'd like to add the option `--single-transaction --quick` to the mysqldump command. This should speed up larger database exports without tearing the environment up whilst doing so... 
(see https://dev.mysql.com/doc/refman/5.7/en/mysqldump.html#option_mysqldump_single-transaction)

Another way would be to allow for custom config to be loaded which inludes a optional `[mysqldump]` section... 

Another (even better perhaps) solution would be to have non-s3-backup command that utilizes the i.e. percona xtrabackup as the backup mechanism (and restore) but that changes from simple SQL backups to more advanced full database stuff...