### PR TITLE
Add --no-tablespaces to the mysqldump command

### DIFF
--- a/functions
+++ b/functions
@@ -117,7 +117,7 @@ service_export() {
 
   [[ -n $SSH_TTY ]] && stty -opost
   docker exec "$SERVICE_NAME" bash -c "printf '[client]\ndefault-character-set=utf8mb4\npassword=$PASSWORD\n' > /root/credentials.cnf"
-  docker exec "$SERVICE_NAME" mysqldump --defaults-extra-file=/root/credentials.cnf --user=mysql --single-transaction --quick "$DATABASE_NAME"
+  docker exec "$SERVICE_NAME" mysqldump --defaults-extra-file=/root/credentials.cnf --user=mysql --single-transaction --no-tablespaces --quick "$DATABASE_NAME"
   docker exec "$SERVICE_NAME" rm /root/credentials.cnf
   status=$?
   [[ -n $SSH_TTY ]] && stty opost


### PR DESCRIPTION
Fixes #140 

Adds the No tablespaces flag to the mysqldump command to avoid the error

> mysqldump: Error: 'Access denied; you need (at least one of) the PROCESS privilege(s) for this operation' when trying to dump tablespaces

