### PR TITLE
feat: respect DOKKU_LIB_HOST_ROOT for mounted data volumes

### DIFF
--- a/config
+++ b/config
@@ -3,7 +3,8 @@ _DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 export MYSQL_IMAGE=${MYSQL_IMAGE:="$(awk -F '[ :]' '{print $2}' "${_DIR}/Dockerfile")"}
 export MYSQL_IMAGE_VERSION=${MYSQL_IMAGE_VERSION:="$(awk -F '[ :]' '{print $3}' "${_DIR}/Dockerfile")"}
 export MYSQL_ROOT=${MYSQL_ROOT:="$DOKKU_LIB_ROOT/services/mysql"}
-export MYSQL_HOST_ROOT=${MYSQL_HOST_ROOT:=$MYSQL_ROOT}
+export DOKKU_LIB_HOST_ROOT=${DOKKU_LIB_HOST_ROOT:=$DOKKU_LIB_ROOT}
+export MYSQL_HOST_ROOT=${MYSQL_HOST_ROOT:="$DOKKU_LIB_HOST_ROOT/services/mysql"}
 
 export PLUGIN_UNIMPLEMENTED_SUBCOMMANDS=()
 export PLUGIN_COMMAND_PREFIX="mysql"


### PR DESCRIPTION
This change allows folks to change where dokku mounts data from for all official plugins, removing the need to specify the configuration on a one-off basis.

Refs dokku/dokku#5468